### PR TITLE
Prevent buffer overflow when saving fruit + traps

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -39,11 +39,6 @@ STATIC_DCL void FDECL(savelev0, (int,XCHAR_P,int));
 STATIC_DCL boolean NDECL(swapout_oldest);
 STATIC_DCL void FDECL(copyfile, (char *,char *));
 #endif /* MFLOPPY */
-#ifdef GCC_WARN
-static long nulls[10];
-#else
-#define nulls nul
-#endif
 
 #if defined(UNIX) || defined(VMS) || defined(__EMX__) || defined(WIN32)
 #define HUP	if (!program_state.done_hup)
@@ -999,6 +994,7 @@ register int fd, mode;
 register struct trap *trap;
 {
 	register struct trap *trap2;
+	static struct trap zerotrap;
 
 	while (trap) {
 	    trap2 = trap->ntrap;
@@ -1009,7 +1005,7 @@ register struct trap *trap;
 	    trap = trap2;
 	}
 	if (perform_bwrite(mode))
-	    bwrite(fd, (genericptr_t)nulls, sizeof(struct trap));
+	    bwrite(fd, (genericptr_t) &zerotrap, sizeof(struct trap));
 }
 
 /* save all the fruit names and ID's; this is used only in saving whole games
@@ -1022,6 +1018,7 @@ savefruitchn(fd, mode)
 register int fd, mode;
 {
 	register struct fruit *f2, *f1;
+	static struct fruit zerofruit;
 
 	f1 = ffruit;
 	while (f1) {
@@ -1033,7 +1030,7 @@ register int fd, mode;
 	    f1 = f2;
 	}
 	if (perform_bwrite(mode))
-	    bwrite(fd, (genericptr_t)nulls, sizeof(struct fruit));
+	    bwrite(fd, (genericptr_t) &zerofruit, sizeof(struct fruit));
 	if (release_data(mode))
 	    ffruit = 0;
 }


### PR DESCRIPTION
This was fixed in both vanilla and dnh the same way - using a static
struct initialisation behaviour rather than relying on a buffer of 0