### PR TITLE
Small memory leak when compiling levels

### DIFF
--- a/sys/share/lev_yacc.c
+++ b/sys/share/lev_yacc.c
@@ -1603,6 +1603,7 @@ case 73:
 			}
 			else if (tmprdoor[ndoor])
 			    tmprdoor[ndoor]->arti_key = token;
+			free(yyvsp[0].map);
 		  }
 break;
 case 80:
@@ -1992,6 +1993,7 @@ case 164:
 			}
 			else
 			    tmpdoor[ndoor]->arti_key = token;
+			free(yyvsp[0].map);
 		  }
 break;
 case 165:

--- a/util/lev_comp.y
+++ b/util/lev_comp.y
@@ -633,6 +633,7 @@ room_door_info	: ',' string
 			}
 			else if (tmprdoor[ndoor])
 			    tmprdoor[ndoor]->arti_key = token;
+			free($2);
 		  }
 		;
 
@@ -1086,6 +1087,7 @@ door_info	: ',' string
 			}
 			else
 			    tmpdoor[ndoor]->arti_key = token;
+			free($2);
 		  }
 		;
 


### PR DESCRIPTION
Vlad's level had extra information for its doors, corresponding to the
artifact key required to open it - leaked about 108 bytes