### PR TITLE
Add LFLAGS to the util autoconf makefile

### DIFF
--- a/sys/autoconf/Makefile.utl
+++ b/sys/autoconf/Makefile.utl
@@ -97,7 +97,7 @@ CC = @CC@ -DAUTOCONF
 # CFLAGS = -g -I../include -I$(srcdir)/../include
 
 CFLAGS = -O -I../include -I$(srcdir)/../include @CFLAGS@
-LFLAGS =
+LFLAGS = @LFLAGS@
 
 LIBS =
  


### PR DESCRIPTION
This was missing, so trying to configure in sanitization options would
be omitted entirely

Perhaps it would be better to have separately configured variables for
these than the usual cflags and lflags, but for now it doesn't matter