### PR TITLE
Fix a couple of out of bounds string comparisons

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1489,12 +1489,12 @@ const char *oldstr;
 	    (len >= 5 && (!strcmp(spot-4, "sheep") ||
 			!strcmp(spot-4, "ninja") ||
 			!strcmp(spot-4, "shito") ||
-			!strcmp(spot-7, "shuriken") ||
 			!strcmp(spot-4, "tengu") ||
 			!strcmp(spot-4, "manes"))) ||
 	    (len >= 6 && (!strcmp(spot-5, "ki-rin") ||
 			!strcmp(spot-5, "Nazgul"))) ||
-	    (len >= 7 && !strcmp(spot-6, "gunyoki")))
+	    (len >= 7 && !strcmp(spot-6, "gunyoki")) ||
+	    (len >= 8 && !strcmp(spot-7, "shuriken")))
 		goto bottom;
 
 	/* man/men ("Wiped out all cavemen.") */
@@ -1598,7 +1598,7 @@ const char *oldstr;
 		goto bottom;
 	}
 	if (len >= 5 && (!strcmp(spot-4, "matzo")
-					|| !strcmp(spot-5, "matza"))) {
+					|| !strcmp(spot-4, "matza"))) {
 		Strcpy(spot, "ot");
 		goto bottom;
 	}


### PR DESCRIPTION
It seems like every variant features an issue around here, and the
shuriken one in particular has been seen in every 3.4 variant