### PR TITLE
Prevent blowing the stack when engulfed

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -2522,11 +2522,6 @@ docorner(xmin, ymax)
     register int y;
     register struct WinDesc *cw = wins[WIN_MAP];
 
-    if (u.uswallow) {	/* Can be done more efficiently */
-	swallowed(1);
-	return;
-    }
-
 #if defined(SIGWINCH) && defined(CLIPPING)
     if(ymax > LI) ymax = LI;		/* can happen if window gets smaller */
 #endif


### PR DESCRIPTION
This was fixed in dnh in the same way - with this there it's possible to
get in an infinite loop of being swallowed and displaying it, blowing
the stack