### PR TITLE
Prevent overflow in movement strings

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3335,7 +3335,10 @@ char sym;
 	if(iflags.num_pad) sdp = ndir; else sdp = sdir;	/* DICE workaround */
 
 	u.dz = 0;
-	if(!(dp = index(sdp, sym))) return 0;
+	dp = index(sdp, sym);
+	if (!dp || !*dp)
+	    return 0;
+
 	u.dx = xdir[dp-sdp];
 	u.dy = ydir[dp-sdp];
 	u.dz = zdir[dp-sdp];


### PR DESCRIPTION
This fix is taken from vanilla, though we saw it in dnh as well
It could index into strings out of bounds depending on the input