### PR TITLE
Read after free engraving with exploding wand

### DIFF
--- a/src/engrave.c
+++ b/src/engrave.c
@@ -956,11 +956,12 @@ doengrave()
 		You("are not going to get anywhere trying to write in the %s with your dust.",
 		    is_ice(u.ux,u.uy) ? "frost" : "dust");
 	    useup(otmp);
+	    otmp = 0; /* wand is now gone */
 	    ptext = FALSE;
 	}
 
 	if (!ptext) {		/* Early exit for some implements. */
-	    if (otmp->oclass == WAND_CLASS && !can_reach_floor())
+	    if (otmp && otmp->oclass == WAND_CLASS && !can_reach_floor())
 		You_cant("reach the %s!", surface(u.ux,u.uy));
 	    return(1);
 	}


### PR DESCRIPTION
The wand would be freed and then immediately checked as part of the
levitation check