### PR TITLE
Fix use after free from monsters reading/quaffing

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -1570,9 +1570,10 @@ struct monst *mtmp;
 	    	    	}
 		    }
 		}
+		boolean wascursed = otmp->cursed;
 		m_useup(mtmp, otmp);
 		/* Attack the player */
-		if (distmin(mmx, mmy, u.ux, u.uy) == 1 && !otmp->cursed) {
+		if (distmin(mmx, mmy, u.ux, u.uy) == 1 && !wascursed) {
 		    int dmg;
 		    struct obj *otmp2;
 
@@ -2364,7 +2365,6 @@ boolean stoning;
 	obj->quan = save_quan;
     } else if (flags.soundok)
 	You_hear("%s.", (obj->otyp == POT_ACID) ? "drinking" : "chewing");
-    m_useup(mon, obj);
     if (((obj->otyp == POT_ACID) || acidic(&mons[obj->corpsenm])) &&
 		    !resists_acid(mon)) {
 	mon->mhp -= rnd(15);
@@ -2372,6 +2372,7 @@ boolean stoning;
 	    Monnam(mon));
     }
     if (mon->mhp <= 0) {
+	m_useup(mon, obj);
 	pline("%s dies!", Monnam(mon));
 	if (by_you) xkilled(mon, 0);
 	else mondead(mon);
@@ -2396,6 +2397,7 @@ boolean stoning;
 	edog->hungrytime += nutrit;
 	mon->mconf = 0;
     }
+    m_useup(mon, obj);
     mon->mlstmv = monstermoves; /* it takes a turn */
 }
 


### PR DESCRIPTION
Two cases where a monster uses a scroll or quaffs a potion and the game
immediately reads data from the freed object

We get the data before the free occurs, or use up the item as late as
possible