### PR TITLE
Fix read after free with monster scroll of earth

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -876,11 +876,12 @@ register struct obj	*sobj;
 
 		otmp = some_armor(&youmonst);
 		if(!otmp) {
+			boolean iscursed = sobj->cursed;
 			strange_feeling(sobj,
 					!Blind ? "Your skin glows then fades." :
 					"Your skin feels warm for a moment.");
-			exercise(A_CON, !sobj->cursed);
-			exercise(A_STR, !sobj->cursed);
+			exercise(A_CON, !iscursed);
+			exercise(A_STR, !iscursed);
 			return(1);
 		}
 		if(confused) {


### PR DESCRIPTION
For scroll of earth specifically, it would consume the scroll and then
immediately check whether it was cursed