### PR TITLE
Ensure item destruction doesn't read freed obj

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -4743,7 +4743,7 @@ register int osym, dmgtyp;
 		     * any "next" pointers that would otherwise become invalid.
 		     */
 		    struct destroy_item_frame *fp;
-		    for(fp = frame.next_frame; fp; fp = fp->next_frame) {
+		    for(fp = &frame; fp; fp = fp->next_frame) {
 			if (fp->next_obj == obj)
 			    fp->next_obj = frame.next_obj;
 		    }


### PR DESCRIPTION
This one is really tricky and someone should sanity check this before it
gets merged...

When items get destroyed by a wand of lightning, it builds up a stack of
frames to check as items may explode destroying other items. This is a
little tricky though, and the current item may be destroyed as part of
this routine.

I modified the guard to also ensure the current frame is checked, not
just the subsequent frames, and haven't since seen the address sanitizer
tripping on this.