### PR TITLE
Prevent cutworm segfault

### DIFF
--- a/src/worm.c
+++ b/src/worm.c
@@ -367,9 +367,18 @@ cutworm(worm, x, y, weap)
      *  At this point, the old worm is correct.  Any new worm will have
      *  it's head at "curr" and its tail at "new_tail".
      */
+    new_worm = 0;
+    new_wnum = (worm->m_lev >= 3 && !rn2(3)) ? get_wormno() : 0;
+    if (new_wnum) {
+        remove_monster(x, y); /* clone_mon puts new head here */
+        /* clone_mon() will fail if enough long worms have been
+           created to have them be marked as extinct or if the hit
+           that cut the current one has dropped it down to 1 HP */
+        new_worm = clone_mon(worm, x, y);
+    }
 
     /* Sometimes the tail end dies. */
-    if (rn2(3) || !(new_wnum = get_wormno())) {
+    if (!new_worm) {
 	if (flags.mon_moving)
 	    pline("Part of the tail of %s is cut off.", mon_nam(worm));
 	else
@@ -379,13 +388,10 @@ cutworm(worm, x, y, weap)
 	return 1;
     }
 
-    remove_monster(x, y);		/* clone_mon puts new head here */
-    new_worm = clone_mon(worm, x, y);
     new_worm->wormno = new_wnum;	/* affix new worm number */
 
     /* Devalue the monster level of both halves of the worm. */
-    worm->m_lev = ((unsigned)worm->m_lev <= 3) ?
-		   (unsigned)worm->m_lev : max((unsigned)worm->m_lev - 2, 3);
+    worm->m_lev = max((unsigned)worm->m_lev - 2, 3);
     new_worm->m_lev = worm->m_lev;
 
     /* Calculate the mhp on the new_worm for the (lower) monster level. */


### PR DESCRIPTION
This occurs when clone_mon fails (there's a few valid reasons for this)

We take vanilla's fix for this and include the vanilla fix to only
let worms above level 3 split, preventing 0d8 rolls