### PR TITLE
Prevent impossible when visiting full floor

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1298,8 +1298,16 @@ boolean at_stairs, falling, portal;
 		mnexto(mtmp);
 
 	    if ((mtmp = m_at(u.ux, u.uy)) != 0) {
-		impossible("mnexto failed (do.c)?");
-		(void) rloc(mtmp, FALSE);
+#ifdef WIZARD
+		/* there was an unconditional impossible("mnexto failed")
+		   here, but it's not impossible and we're prepared to cope
+		   with the situation, so only say something when debugging */
+		if (wizard) pline("(monster in hero's way)");
+#endif
+		if (!rloc(mtmp, TRUE))
+		    /* no room to move it; send it away, to return later */
+		    migrate_to_level(mtmp, ledger_no(&u.uz),
+			    MIGR_RANDOM, (coord *)0);
 	    }
 	}
 


### PR DESCRIPTION
If the monster could not be relocated, this would throw an impossible
and funky things may occur. We take the vanilla change that migrates the
monster to the same floor it ought to be on.