### PR TITLE
Suppress impossibles for unicorn/tengu teleport

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -767,7 +767,7 @@ register int after;
 	if(ptr == &mons[PM_TENGU] && !rn2(5) && !mtmp->mcan &&
 	   !tele_restrict(mtmp)) {
 	    if(mtmp->mhp < 7 || mtmp->mpeaceful || rn2(2))
-		(void) rloc(mtmp, FALSE);
+		(void) rloc(mtmp, TRUE);
 	    else
 		mnexto(mtmp);
 	    mmoved = 1;
@@ -1102,7 +1102,7 @@ not_special:
 	    if (mtmp->wormno) worm_move(mtmp);
 	} else {
 	    if(is_unicorn(ptr) && rn2(2) && !tele_restrict(mtmp)) {
-		(void) rloc(mtmp, FALSE);
+		(void) rloc(mtmp, TRUE);
 		return(1);
 	    }
 	    if(mtmp->wormno) worm_nomove(mtmp);


### PR DESCRIPTION
Just like vanilla, suppress the impossibles for the case where they want
to teleport to a location but cannot as every other square is occupied