### PR TITLE
Prevent read after free from crystal ballsplosion

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -245,7 +245,7 @@ E int FDECL(object_detect, (struct obj *,int));
 E int FDECL(monster_detect, (struct obj *,int));
 E int FDECL(trap_detect, (struct obj *));
 E const char *FDECL(level_distance, (d_level *));
-E void FDECL(use_crystal_ball, (struct obj *));
+E void FDECL(use_crystal_ball, (struct obj **));
 E void NDECL(do_mapping);
 E void NDECL(do_vicinity_map);
 E void FDECL(cvt_sdoor_to_door, (struct rm *));

--- a/src/apply.c
+++ b/src/apply.c
@@ -3679,7 +3679,7 @@ doapply()
 		res = use_towel(obj);
 		break;
 	case CRYSTAL_BALL:
-		use_crystal_ball(obj);
+		use_crystal_ball(&obj);
 		break;
 /* STEPHEN WHITE'S NEW CODE */
 /* KMH, balance patch -- source of abuse */

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1461,7 +1461,7 @@ doinvoke()
 
 STATIC_OVL int
 arti_invoke(obj)
-    register struct obj *obj;
+    struct obj *obj;
 {
     register const struct artifact *oart = get_artifact(obj);
 	    register struct monst *mtmp;
@@ -1476,7 +1476,7 @@ arti_invoke(obj)
 
     if(!oart || !oart->inv_prop) {
 	if(obj->otyp == CRYSTAL_BALL)
-	    use_crystal_ball(obj);
+	    use_crystal_ball(&obj);
 	else
 	    pline(nothing_happens);
 	return 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -802,11 +802,12 @@ static const struct {
 };
 
 void
-use_crystal_ball(obj)
-struct obj *obj;
+use_crystal_ball(obj_p)
+struct obj **obj_p;
 {
     char ch;
     int oops;
+    struct obj *obj = *obj_p;
 
     if (Blind) {
 	pline("Too bad you can't see %s.", the(xname(obj)));
@@ -834,7 +835,7 @@ struct obj *obj;
 	    break;
 	case 5 : pline("%s!", Tobjnam(obj, "explode"));
 	    useup(obj);
-	    obj = 0;	/* it's gone */
+	    *obj_p = obj = 0;	/* it's gone */
 	    losehp(rnd(30), "exploding crystal ball", KILLED_BY_AN);
 	    break;
 	}


### PR DESCRIPTION
We use vanilla's fix here, allowing use_crystal_ball to modify the
object pointer in the parent scope