### PR TITLE
Guard against returning negative techval

### DIFF
--- a/src/tech.c
+++ b/src/tech.c
@@ -499,7 +499,13 @@ dotechmenu(how, tech_no)
 	n = select_menu(tmpwin, how, &selected);
 	destroy_nhwindow(tmpwin);
 	if (n > 0) {
-	    *tech_no = selected[0].item.a_int - 1;
+	    int selection = selected[0].item.a_int - 1;
+	    /* This really shouldn't happen, and yet it does */
+	    if (selection < 0) {
+		free((genericptr_t)selected);
+		return FALSE;
+	    }
+	    *tech_no = selection;
 	    free((genericptr_t)selected);
 	    return TRUE;
 	}


### PR DESCRIPTION
Really this should just never happen, but there's some weirdness in
setting up the menus for techniques that allows it to happen.

We mark it as an invalid selection here, though it could be revisited in
the future