### PR TITLE
Port HANGUPHANDLING and SAFERHANGUP

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -173,15 +173,15 @@ E struct linfo level_info[MAXLINFO];
 E NEARDATA struct sinfo {
 	int gameover;		/* self explanatory? */
 	int stopprint;		/* inhibit further end of game disclosure */
-#if defined(UNIX) || defined(VMS) || defined (__EMX__) || defined(WIN32)
-	int done_hup;		/* SIGHUP or moral equivalent received
+#if defined(HANGUPHANDLING)
+	volatile int done_hup;	/* SIGHUP or moral equivalent received
 				 * -- no more screen output */
+	int preserve_locks;    /* don't remove level files prior to exit */
 #endif
 	int something_worth_saving;	/* in case of panic */
 	int panicking;		/* `panic' is in progress */
-#if defined(VMS) || defined(WIN32)
 	int exiting;		/* an exit handler is executing */
-#endif
+	int in_moveloop;
 	int in_impossible;
 #ifdef PANICLOG
 	int in_paniclog;

--- a/include/extern.h
+++ b/include/extern.h
@@ -212,6 +212,10 @@ E void NDECL(confdir);
 E int FDECL(isok, (int,int));
 E int FDECL(get_adjacent_loc, (const char *, const char *, XCHAR_P, XCHAR_P, coord *));
 E const char *FDECL(click_to_cmd, (int,int,int));
+#ifdef HANGUPHANDLING
+E void FDECL(hangup, (int));
+E void NDECL(end_of_input);
+#endif
 E char NDECL(readchar);
 #ifdef WIZARD
 E void NDECL(sanity_check);
@@ -2494,8 +2498,11 @@ E void FDECL(unwield, (struct obj *,BOOLEAN_P));
 /* ### windows.c ### */
 
 E void FDECL(choose_windows, (const char *));
-E char FDECL(genl_message_menu, (CHAR_P,int,const char *));
+E char FDECL(genl_message_menu, (int,int,const char *));
 E void FDECL(genl_preference_update, (const char *));
+#ifdef HANGUPHANDLING
+E void NDECL(nhwindows_hangup);
+#endif
 
 /* ### wizard.c ### */
 

--- a/include/global.h
+++ b/include/global.h
@@ -329,6 +329,14 @@ typedef xchar	boolean;		/* 0 or 1 */
 # endif
 #endif
 
+#if defined(UNIX) || defined(VMS) || defined(__EMX__) || defined(WIN32)
+#define HANGUPHANDLING
+#endif
+#if defined(SAFERHANGUP) \
+    && (defined(NOSAVEONHANGUP) || !defined(HANGUPHANDLING))
+#undef SAFERHANGUP
+#endif
+
 #define Sprintf  (void) sprintf
 #define Strcat   (void) strcat
 #define Strcpy   (void) strcpy

--- a/include/unixconf.h
+++ b/include/unixconf.h
@@ -323,6 +323,13 @@
 #define SUSPEND		/* let ^Z suspend the game */
 #endif
 
+/*
+ * Define SAFERHANGUP to delay hangup processing until the main command
+ * loop. 'safer' because it avoids certain cheats and also avoids losing
+ * objects being thrown when the hangup occurs.  All unix windowports
+ * support SAFERHANGUP (couldn't define it here otherwise).
+ */
+#define SAFERHANGUP
 
 #if defined(BSD) || defined(ULTRIX)
 #include <sys/time.h>

--- a/include/wceconf.h
+++ b/include/wceconf.h
@@ -76,6 +76,12 @@
 
 #define PORT_HELP	"porthelp"
 
+#define SAFERHANGUP /* Define SAFERHANGUP to delay hangup processing   \
+                     * until the main command loop. 'safer' because it \
+                     * avoids certain cheats and also avoids losing    \
+                     * objects being thrown when the hangup occurs.    \
+                     */
+
 #if defined(WIN_CE_POCKETPC)
 #	define PORT_CE_PLATFORM "Pocket PC"
 #elif defined(WIN_CE_PS2xx)

--- a/include/winprocs.h
+++ b/include/winprocs.h
@@ -71,7 +71,11 @@ struct window_procs {
     void FDECL((*win_preference_update), (const char *));
 };
 
-extern NEARDATA struct window_procs windowprocs;
+extern
+#ifdef HANGUPHANDLING
+    volatile
+#endif
+    NEARDATA struct window_procs windowprocs;
 
 /*
  * If you wish to only support one window system and not use procedure

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -77,7 +77,13 @@ moveloop()
     u.uz0.dlevel = u.uz.dlevel;
     youmonst.movement = NORMAL_SPEED;	/* give the hero some movement points */
 
+    program_state.in_moveloop = 1;
+
     for(;;) {
+#ifdef SAFERHANGUP
+        if (program_state.done_hup)
+            end_of_input();
+#endif
 	get_nh_event();
 #ifdef POSITIONBAR
 	do_positionbar();

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -213,7 +213,7 @@ adjattrib(ndx, incr, msgflg)
 		  (incr > 1 || incr < -1) ? "very ": "",
 		  (incr > 0) ? plusattr[ndx] : minusattr[ndx]);
 	flags.botl = 1;
-	if (msgflg <= 1 && moves > 1 && (ndx == A_STR || ndx == A_CON))
+	if (program_state.in_moveloop && msgflg <= 1 && moves > 1 && (ndx == A_STR || ndx == A_CON))
 		(void)encumber_msg();
 	return TRUE;
 }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -171,10 +171,8 @@ static NEARDATA struct rm *maploc;
 #ifdef OVLB
 STATIC_DCL void FDECL(enlght_line, (const char *,const char *,const char *));
 STATIC_DCL char *FDECL(enlght_combatinc, (const char *,int,int,char *));
-#ifdef UNIX
-static void NDECL(end_of_input);
-#endif
 #endif /* OVLB */
+void NDECL(end_of_input);
 
 static const char* readchar_queue="";
 
@@ -207,6 +205,59 @@ timed_occupation()
 		multi--;
 	return multi > 0;
 }
+
+#ifdef HANGUPHANDLING
+/* some very old systems, or descendents of such systems, expect signal
+   handlers to have return type `int', but they don't actually inspect
+   the return value so we should be safe using `void' unconditionally */
+/*ARGUSED*/
+void
+hangup(int sig_unused)   /* called as signal() handler, so sent
+                                   at least one arg */
+{
+    if (program_state.exiting)
+        program_state.in_moveloop = 0;
+    nhwindows_hangup();
+#ifdef SAFERHANGUP
+    /* When using SAFERHANGUP, the done_hup flag it tested in rhack
+       and a couple of other places; actual hangup handling occurs then.
+       This is 'safer' because it disallows certain cheats and also
+       protects against losing objects in the process of being thrown,
+       but also potentially riskier because the disconnected program
+       must continue running longer before attempting a hangup save. */
+    program_state.done_hup++;
+    /* defer hangup iff game appears to be in progress */
+    if (program_state.in_moveloop && program_state.something_worth_saving)
+        return;
+#endif /* SAFERHANGUP */
+    end_of_input();
+}
+
+void
+end_of_input(void)
+{
+#ifdef NOSAVEONHANGUP
+#ifdef INSURANCE
+    if (flags.ins_chkpt && program_state.something_worth_saving)
+        program_state.preserve_locks = 1; /* keep files for recovery */
+#endif
+    program_state.something_worth_saving = 0; /* don't save */
+#endif
+
+#ifndef SAFERHANGUP
+    if (!program_state.done_hup++)
+#endif
+        if (program_state.something_worth_saving)
+            (void) dosave0();
+    if (iflags.window_inited)
+        exit_nhwindows((char *) 0);
+    clearlocks();
+    terminate(EXIT_SUCCESS);
+    /*NOTREACHED*/ /* not necessarily true for vms... */
+    return;
+}
+#endif /* HANGUPHANDLING */
+
 
 /* If you have moved since initially setting some occupations, they
  * now shouldn't be able to restart.
@@ -3106,6 +3157,10 @@ register char *cmd;
 		firsttime = (cmd == 0);
 
 	iflags.menu_requested = FALSE;
+#ifdef SAFERHANGUP
+    if (program_state.done_hup)
+        end_of_input();
+#endif
 	if (firsttime) {
 		flags.nopick = 0;
 		cmd = parse();
@@ -3736,24 +3791,6 @@ parse()
 }
 
 #endif /* OVL0 */
-#ifdef OVLB
-
-#ifdef UNIX
-static
-void
-end_of_input()
-{
-#ifndef NOSAVEONHANGUP
-	if (!program_state.done_hup++ && program_state.something_worth_saving)
-	    (void) dosave0();
-#endif
-	exit_nhwindows((char *)0);
-	clearlocks();
-	terminate(EXIT_SUCCESS);
-}
-#endif
-
-#endif /* OVLB */
 #ifdef OVL0
 
 char
@@ -3789,7 +3826,9 @@ readchar()
 	}
 # endif /* NR_OF_EOFS */
 	if (sym == EOF)
-	    end_of_input();
+#ifdef HANGUPHANDLING
+	    hangup(0); /* call end_of_input() or set program_state.done_hup */
+#endif
 #endif /* UNIX */
 
 	if(sym == 0) {

--- a/src/display.c
+++ b/src/display.c
@@ -752,6 +752,10 @@ newsym(x,y)
     register xchar worm_tail;
 
     if (in_mklev) return;
+#ifdef HANGUPHANDLING
+    if (program_state.done_hup)
+        return;
+#endif
 
     /* only permit updating the hero when swallowed */
     if (u.uswallow) {
@@ -1646,6 +1650,10 @@ flush_screen(cursor_on_u)
     if (delay_flushing) return;
     if (flushing) return;	/* if already flushing then return */
     flushing = 1;
+#ifdef HANGUPHANDLING
+    if (program_state.done_hup)
+        return;
+#endif
 
     for (y = 0; y < ROWNO; y++) {
 	register gbuf_entry *gptr = &gbuf[y][x = gbuf_start[y]];

--- a/src/end.c
+++ b/src/end.c
@@ -839,6 +839,10 @@ die:
 	program_state.gameover = 1;
 	/* in case of a subsequent panic(), there's no point trying to save */
 	program_state.something_worth_saving = 0;
+#ifdef HANGUPHANDLING
+	if (program_state.done_hup)
+	  done_stopprint++;
+#endif
 #ifdef DUMP_LOG
 	/* D: Grab screen dump right here */
 	if (dump_fn[0]) {
@@ -1314,6 +1318,8 @@ void
 terminate(status)
 int status;
 {
+
+	program_state.in_moveloop = 0; /* won't be returning to normal play */
 #ifdef MAC
 	getreturn("to exit");
 #endif
@@ -1324,6 +1330,7 @@ int status;
 	    dlb_cleanup();
 	}
 
+	program_state.exiting = 1;
 	nethack_exit(status);
 }
 

--- a/src/files.c
+++ b/src/files.c
@@ -581,22 +581,17 @@ int lev;
 void
 clearlocks()
 {
-/* [Tom] Watcom.....
-#if !defined(PC_LOCKING) && defined(MFLOPPY) && !defined(AMIGA)
-	eraseall(levels, alllevels);
-	if (ramdisk)
-		eraseall(permbones, alllevels);
-#else
-	register int x;
-
+#ifdef HANGUPHANDLING
+    if (program_state.preserve_locks)
+        return;
+#endif
 # if defined(UNIX) || defined(VMS)
 	(void) signal(SIGHUP, SIG_IGN);
-# endif */
+# endif
 	/* can't access maxledgerno() before dungeons are created -dlc */
 	int x;
 	for (x = (n_dgns ? maxledgerno() : 0); x >= 0; x--)
 		delete_levelfile(x);	/* not all levels need be present */
-/* #endif*/
 }
 
 #ifdef HOLD_LOCKFILE_OPEN

--- a/src/mon.c
+++ b/src/mon.c
@@ -684,6 +684,17 @@ movemon()
     */
 
     for(mtmp = fmon; mtmp; mtmp = nmtmp) {
+        /* end monster movement early if hero is flagged to leave the level */
+        if (u.utotype
+#ifdef SAFERHANGUP
+            /* or if the program has lost contact with the user */
+            || program_state.done_hup
+#endif
+            ) {
+            somebody_can_move = FALSE;
+            break;
+        }
+
 	nmtmp = mtmp->nmon;
 
 	/* Find a monster that we have not treated yet.	 */

--- a/src/pline.c
+++ b/src/pline.c
@@ -99,6 +99,10 @@ pline VA_DECL(const char *, line)
 /* Do NOT use VA_START and VA_END in here... see above */
 
 	if (!line || !*line) return;
+#ifdef HANGUPHANDLING
+	if (program_state.done_hup)
+	    return;
+#endif
 	if (index(line, '%')) {
 	    Vsprintf(pbuf,line,VA_ARGS);
 	    line = pbuf;

--- a/src/save.c
+++ b/src/save.c
@@ -131,37 +131,6 @@ dosave()
 }
 
 
-#if defined(UNIX) || defined(VMS) || defined (__EMX__) || defined(WIN32)
-/*ARGSUSED*/
-void
-hangup(sig_unused)  /* called as signal() handler, so sent at least one arg */
-int sig_unused;
-{
-# ifdef NOSAVEONHANGUP
-	(void) signal(SIGINT, SIG_IGN);
-	clearlocks();
-#  ifndef VMS
-	terminate(EXIT_FAILURE);
-#  endif
-# else	/* SAVEONHANGUP */
-	if (!program_state.done_hup++) {
-	    if (program_state.something_worth_saving)
-		(void) dosave0();
-#  ifdef VMS
-	    /* don't call exit when already within an exit handler;
-	       that would cancel any other pending user-mode handlers */
-	    if (!program_state.exiting)
-#  endif
-	    {
-		clearlocks();
-		terminate(EXIT_FAILURE);
-	    }
-	}
-# endif
-	return;
-}
-#endif
-
 /* returns 1 if save successful */
 int
 dosave0()

--- a/src/windows.c
+++ b/src/windows.c
@@ -63,6 +63,9 @@ extern struct window_procs mswin_procs;
 
 STATIC_DCL void FDECL(def_raw_print, (const char *s));
 
+#ifdef HANGUPHANDLING
+volatile
+#endif
 NEARDATA struct window_procs windowprocs;
 
 static
@@ -116,6 +119,409 @@ struct win_choices {
     { 0, 0 }		/* must be last */
 };
 
+/*
+ * tty_message_menu() provides a means to get feedback from the
+ * --More-- prompt; other interfaces generally don't need that.
+ */
+/*ARGSUSED*/
+char
+genl_message_menu(int let,
+                  int how,
+                  const char *mesg)
+{
+    pline("%s", mesg);
+    return 0;
+}
+
+/*ARGSUSED*/
+void
+genl_preference_update(const char *pref)
+{
+    /* window ports are expected to provide
+       their own preference update routine
+       for the preference capabilities that
+       they support.
+       Just return in this genl one. */
+    return;
+}
+
+char *
+genl_getmsghistory(boolean init)
+{
+    /* window ports can provide
+       their own getmsghistory() routine to
+       preserve message history between games.
+       The routine is called repeatedly from
+       the core save routine, and the window
+       port is expected to successively return
+       each message that it wants saved, starting
+       with the oldest message first, finishing
+       with the most recent.
+       Return null pointer when finished.
+     */
+    return (char *) 0;
+}
+
+void
+genl_putmsghistory(const char *msg, boolean is_restoring)
+{
+    /* window ports can provide
+       their own putmsghistory() routine to
+       load message history from a saved game.
+       The routine is called repeatedly from
+       the core restore routine, starting with
+       the oldest saved message first, and
+       finishing with the latest.
+       The window port routine is expected to
+       load the message recall buffers in such
+       a way that the ordering is preserved.
+       The window port routine should make no
+       assumptions about how many messages are
+       forthcoming, nor should it assume that
+       another message will follow this one,
+       so it should keep all pointers/indexes
+       intact at the end of each call.
+    */
+
+    /* this doesn't provide for reloading the message window with the
+       previous session's messages upon restore, but it does put the quest
+       message summary lines there by treating them as ordinary messages */
+    if (!is_restoring)
+        pline("%s", msg);
+    return;
+}
+
+#ifdef HANGUPHANDLING
+/*
+ * Dummy windowing scheme used to replace current one with no-ops
+ * in order to avoid all terminal I/O after hangup/disconnect.
+ */
+
+static int hup_nhgetch(void);
+static char hup_yn_function(const char *, const char *, int);
+static int hup_nh_poskey(int *, int *, int *);
+static void hup_getlin(const char *, char *);
+static void hup_init_nhwindows(int *, char **);
+static void hup_exit_nhwindows(const char *);
+static winid hup_create_nhwindow(int);
+static int hup_select_menu(winid, int, MENU_ITEM_P **);
+static void hup_add_menu(winid, int, const anything *, int,
+                         int, int, const char *, int);
+static void hup_end_menu(winid, const char *);
+static void hup_putstr(winid, int, const char *);
+static void hup_print_glyph(winid, int, int, int);
+static void hup_outrip(winid, int);
+static void hup_curs(winid, int, int);
+static void hup_display_nhwindow(winid, int);
+static void hup_display_file(const char *, int);
+#ifdef CLIPPING
+static void hup_cliparound(int, int);
+#endif
+#ifdef CHANGE_COLOR
+static void hup_change_color(int, long, int);
+#ifdef MAC
+static short hup_set_font_name(winid, char *);
+#endif
+static char *hup_get_color_string(void);
+#endif /* CHANGE_COLOR */
+static void hup_status_update(int, genericptr_t, int, int, int,
+                              unsigned long *);
+
+static int hup_int_ndecl(void);
+static void hup_void_ndecl(void);
+static void hup_void_fdecl_int(int);
+static void hup_void_fdecl_winid(winid);
+static void hup_void_fdecl_winid_ulong(winid, unsigned long);
+static void hup_void_fdecl_constchar_p(const char *);
+
+static struct window_procs hup_procs = {
+    "hup", 0L, 0L,
+    hup_init_nhwindows,
+    hup_void_ndecl,                                    /* player_selection */
+    hup_void_ndecl,                                    /* askname */
+    hup_void_ndecl,                                    /* get_nh_event */
+    hup_exit_nhwindows, hup_void_fdecl_constchar_p,    /* suspend_nhwindows */
+    hup_void_ndecl,                                    /* resume_nhwindows */
+    hup_create_nhwindow, hup_void_fdecl_winid,         /* clear_nhwindow */
+    hup_display_nhwindow, hup_void_fdecl_winid,        /* destroy_nhwindow */
+    hup_curs, hup_putstr,
+    hup_display_file, hup_void_fdecl_winid,      /* start_menu */
+    hup_add_menu, hup_end_menu, hup_select_menu, genl_message_menu,
+    hup_void_ndecl,                                /* update_inventory */
+    hup_void_ndecl,                                    /* mark_synch */
+    hup_void_ndecl,                                    /* wait_synch */
+#ifdef CLIPPING
+    hup_cliparound,
+#endif
+#ifdef POSITIONBAR
+    (void (*)(char *)) hup_void_fdecl_constchar_p,    /* update_positionbar */
+#endif
+    hup_print_glyph,
+    hup_void_fdecl_constchar_p,                       /* raw_print */
+    hup_void_fdecl_constchar_p,                       /* raw_print_bold */
+    hup_nhgetch, hup_nh_poskey, hup_void_ndecl,       /* nhbell  */
+    hup_int_ndecl,                                    /* doprev_message */
+    hup_yn_function, hup_getlin, hup_int_ndecl,       /* get_ext_cmd */
+    hup_void_fdecl_int,                               /* number_pad */
+    hup_void_ndecl,                                   /* delay_output  */
+#ifdef CHANGE_COLOR
+    hup_change_color,
+#ifdef MAC
+    hup_void_fdecl_int,                               /* change_background */
+    hup_set_font_name,
+#endif
+    hup_get_color_string,
+#endif /* CHANGE_COLOR */
+    hup_void_ndecl,                                   /* start_screen */
+    hup_void_ndecl,                                   /* end_screen */
+    hup_outrip, genl_preference_update,
+};
+
+static void (*previnterface_exit_nhwindows)(const char *) = 0;
+
+/* hangup has occurred; switch to no-op user interface */
+void
+nhwindows_hangup(void)
+{
+    char *(*previnterface_getmsghistory)(boolean) = 0;
+
+#ifdef ALTMETA
+    /* command processor shouldn't look for 2nd char after seeing ESC */
+    iflags.altmeta = FALSE;
+#endif
+
+    /* don't call exit_nhwindows() directly here; if a hangup occurs
+       while interface code is executing, exit_nhwindows could knock
+       the interface's active data structures out from under itself */
+    if (iflags.window_inited
+        && windowprocs.win_exit_nhwindows != hup_exit_nhwindows)
+        previnterface_exit_nhwindows = windowprocs.win_exit_nhwindows;
+
+    windowprocs = hup_procs;
+}
+
+static void
+hup_exit_nhwindows(const char *lastgasp)
+{
+    /* core has called exit_nhwindows(); call the previous interface's
+       shutdown routine now; xxx_exit_nhwindows() needs to call other
+       xxx_ routines directly rather than through windowprocs pointers */
+    if (previnterface_exit_nhwindows) {
+        lastgasp = 0; /* don't want exit routine to attempt extra output */
+        (*previnterface_exit_nhwindows)(lastgasp);
+        previnterface_exit_nhwindows = 0;
+    }
+    iflags.window_inited = 0;
+}
+
+static int
+hup_nhgetch(void)
+{
+    return '\033'; /* ESC */
+}
+
+/*ARGSUSED*/
+static char
+hup_yn_function(const char *prompt,
+                const char *resp,
+                int deflt)
+{
+    if (!deflt)
+        deflt = '\033';
+    return deflt;
+}
+
+/*ARGSUSED*/
+static int
+hup_nh_poskey(int *x, int *y, int *mod)
+{
+    return '\033';
+}
+
+/*ARGSUSED*/
+static void
+hup_getlin(const char *prompt, char *outbuf)
+{
+    Strcpy(outbuf, "\033");
+}
+
+/*ARGSUSED*/
+static void
+hup_init_nhwindows(int *argc_p, char **argv)
+{
+    iflags.window_inited = 1;
+}
+
+/*ARGUSED*/
+static winid
+hup_create_nhwindow(int type)
+{
+    return WIN_ERR;
+}
+
+/*ARGSUSED*/
+static int
+hup_select_menu(winid window, int how,
+                struct mi **menu_list)
+{
+    return -1;
+}
+
+/*ARGSUSED*/
+static void
+hup_add_menu(winid window,
+             int intglyphinfo,
+             const anything *identifier,
+             int sel,
+             int grpsel,
+             int attr,
+             const char *txt,
+             int itemflags)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_end_menu(winid window, const char *prompt)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_putstr(winid window, int attr, const char *text)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_print_glyph(winid window,
+                int x, int y,
+                int glyphinfo)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_outrip(winid tmpwin, int how)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_curs(winid window, int x, int y)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_display_nhwindow(winid window, int blocking)
+{
+    return;
+}
+
+/*ARGSUSED*/
+static void
+hup_display_file(const char *fname, int complain)
+{
+    return;
+}
+
+#ifdef CLIPPING
+/*ARGSUSED*/
+static void
+hup_cliparound(int x, int y)
+{
+    return;
+}
+#endif
+
+#ifdef CHANGE_COLOR
+/*ARGSUSED*/
+static void
+hup_change_color(int color, int reverse, long rgb)
+{
+    return;
+}
+
+#ifdef MAC
+/*ARGSUSED*/
+static short
+hup_set_font_name(winid window, char *fontname)
+{
+    return 0;
+}
+#endif /* MAC */
+
+static char *
+hup_get_color_string(void)
+{
+    return (char *) 0;
+}
+#endif /* CHANGE_COLOR */
+
+/*ARGSUSED*/
+static void
+hup_status_update(int idx, genericptr_t ptr, int chg,
+                  int pc, int color,
+                  unsigned long *colormasks)
+{
+    return;
+}
+
+/*
+ * Non-specific stubs.
+ */
+
+static int
+hup_int_ndecl(void)
+{
+    return -1;
+}
+
+static void
+hup_void_ndecl(void)
+{
+    return;
+}
+
+/*ARGUSED*/
+static void
+hup_void_fdecl_int(int arg)
+{
+    return;
+}
+
+/*ARGUSED*/
+static void
+hup_void_fdecl_winid(winid window)
+{
+    return;
+}
+
+/*ARGUSED*/
+static void
+hup_void_fdecl_winid_ulong(winid window,
+                           unsigned long mbehavior)
+{
+    return;
+}
+
+/*ARGUSED*/
+static void
+hup_void_fdecl_constchar_p(const char *string)
+{
+    return;
+}
+
+#endif /* HANGUPHANDLING */
+
+
 STATIC_OVL
 void
 def_raw_print(s)
@@ -163,33 +569,4 @@ const char *s;
     wait_synch();
 }
 
-/*
- * tty_message_menu() provides a means to get feedback from the
- * --More-- prompt; other interfaces generally don't need that.
- */
-/*ARGSUSED*/
-char
-genl_message_menu(let, how, mesg)
-char let;
-int how;
-const char *mesg;
-{
-#if defined(MAC_MPW)
-# pragma unused ( how,let )
-#endif
-    pline("%s", mesg);
-    return 0;
-}
-
-/*ARGSUSED*/
-void
-genl_preference_update(pref)
-const char *pref;
-{
-	/* window ports are expected to provide
-	   their own preference update routine
-	   for the preference capabilities that
-	   they support.
-	   Just return in this genl one. */
-}
 /*windows.c*/

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -148,6 +148,8 @@ char *argv[];
 	 * It seems you really want to play.
 	 */
 	u.uhp = 1;	/* prevent RIP on early quits */
+	program_state.preserve_locks = 1;
+
 	(void) signal(SIGHUP, (SIG_RET_TYPE) hangup);
 #ifdef SIGXCPU
 	(void) signal(SIGXCPU, (SIG_RET_TYPE) hangup);
@@ -202,6 +204,7 @@ char *argv[];
 		getlock();
 	}
 #endif /* WIZARD */
+	program_state.preserve_locks = 0; /* after getlock() */
 
 	dlb_init();	/* must be before newgame() */
 

--- a/sys/unix/unixunix.c
+++ b/sys/unix/unixunix.c
@@ -79,6 +79,7 @@ eraseoldlocks()
 {
 	register int i;
 
+	program_state.preserve_locks = 0; /* not required but shows intent */
 	/* cannot use maxledgerno() here, because we need to find a lock name
 	 * before starting everything (including the dungeon initialization
 	 * that sets astral_level, needed for maxledgerno()) up

--- a/sys/wince/mhinput.c
+++ b/sys/wince/mhinput.c
@@ -33,7 +33,12 @@ void mswin_nh_input_init()
 /* check for input */
 int	mswin_have_input()
 {
-	return (nhi_read_pos!=nhi_write_pos);
+	return
+#ifdef SAFERHANGUP
+        /* we always have input (ESC) if hangup was requested */
+		program_state.done_hup ||
+#endif
+		(nhi_read_pos != nhi_write_pos);
 }
 
 /* add event to the queue */
@@ -57,6 +62,16 @@ PMSNHEvent mswin_input_pop()
 {
 	PMSNHEvent retval;
 
+#ifdef SAFERHANGUP
+	/* always return ESC when hangup was requested */
+	if (program_state.done_hup) {
+		static MSNHEvent hangup_event;
+		hangup_event.type = NHEVENT_CHAR;
+		hangup_event.kbd.ch = '\033';
+		return &hangup_event;
+	}
+#endif
+
 	if( !nhi_init_input ) mswin_nh_input_init();
 
 	if( nhi_read_pos!=nhi_write_pos ) {
@@ -73,6 +88,16 @@ PMSNHEvent mswin_input_pop()
 PMSNHEvent mswin_input_peek()
 {
 	PMSNHEvent retval;
+
+#ifdef SAFERHANGUP
+    /* always return ESC when hangup was requested */
+    if (program_state.done_hup) {
+        static MSNHEvent hangup_event;
+        hangup_event.type = NHEVENT_CHAR;
+        hangup_event.kbd.ch = '\033';
+        return &hangup_event;
+    }
+#endif
 
 	if( !nhi_init_input ) mswin_nh_input_init();
 

--- a/sys/wince/mhmain.c
+++ b/sys/wince/mhmain.c
@@ -479,8 +479,18 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPar
 
 		case WM_CLOSE: 
 		{
-			/* exit gracefully */
-			dosave0();
+		      /* exit gracefully */
+#ifdef SAFERHANGUP
+		      /* destroy popup window - it has its own loop and we need to
+			 return control to NetHack core at this point */
+		      if (IsWindow(GetNHApp()->hPopupWnd))
+			 SendMessage(GetNHApp()->hPopupWnd, WM_COMMAND, IDCANCEL, 0);
+
+		      /* tell NetHack core that "hangup" is requested */
+		      hangup(1);
+#else
+		      dosave0();
+#endif
 		} return 0;
 
 		/*-----------------------------------------------------------------------*/

--- a/util/makedefs.c
+++ b/util/makedefs.c
@@ -780,6 +780,13 @@ static const char *build_opts[] = {
 #ifdef HOLD_LOCKFILE_OPEN
 		"exclusive lock on level 0 file",
 #endif
+#if defined(HANGUPHANDLING) && !defined(NO_SIGNAL)
+#ifdef SAFERHANGUP
+		"deferred handling of hangup signal",
+#else
+		"immediate handling of hangup signal",
+#endif
+#endif
 #ifdef LOGFILE
 		"log file",
 #endif

--- a/win/Qt/qt_win.cpp
+++ b/win/Qt/qt_win.cpp
@@ -129,6 +129,9 @@ extern "C" {
 # endif
 #endif
 
+#ifdef SAFERHANGUP
+#include <qtimer.h>
+#endif
 
 #ifdef USER_SOUNDS
 extern "C" void play_sound_for_message(const char* str);
@@ -1490,7 +1493,17 @@ NetHackQtMapWindow::NetHackQtMapWindow(NetHackQtClickBuffer& click_sink) :
 
     updateTiles();
     //setFocusPolicy(StrongFocus);
+#ifdef SAFERHANGUP
+    QTimer* deadman = new QTimer(this);
+    connect(deadman, SIGNAL(timeout()), SLOT(timeout()));
+    deadman->start(2000);		// deadman timer every 2 seconds
+#endif
 }
+
+#ifdef SAFERHANGUP
+// The "deadman" timer is received by this slot
+void NetHackQtMapWindow::timeout() {}
+#endif
 
 void NetHackQtMapWindow::moveMessages(int x, int y)
 {
@@ -4976,9 +4989,17 @@ int NetHackQtBind::qt_nhgetch()
 
     // Process events until a key arrives.
     //
-    while (keybuffer.Empty()) {
+    while (keybuffer.Empty()
+#ifdef SAFERHANGUP
+	   && !program_state.done_hup
+#endif
+	   ) {
 	qApp->enter_loop();
     }
+
+#ifdef SAFERHANGUP
+    if (program_state.done_hup && keybuffer.Empty()) return '\033';
+#endif
 
     return keybuffer.GetAscii();
 }
@@ -4990,9 +5011,16 @@ int NetHackQtBind::qt_nh_poskey(int *x, int *y, int *mod)
 
     // Process events until a key or map-click arrives.
     //
-    while (keybuffer.Empty() && clickbuffer.Empty()) {
+    while (keybuffer.Empty() && clickbuffer.Empty()
+#ifdef SAFERHANGUP
+	   && !program_state.done_hup
+#endif
+	   ) {
 	qApp->enter_loop();
     }
+#ifdef SAFERHANGUP
+    if (program_state.done_hup && keybuffer.Empty()) return '\033';
+#endif
     if (!keybuffer.Empty()) {
 	return keybuffer.GetAscii();
     } else {
@@ -5238,6 +5266,13 @@ bool NetHackQtBind::notify(QObject *receiver, QEvent *event)
 	return TRUE;
 
     bool result=QApplication::notify(receiver,event);
+#ifdef SAFERHANGUP
+    if (program_state.done_hup) {
+	keybuffer.Put('\033');
+	qApp->exit_loop();
+	return TRUE;
+    }
+#endif
     if (event->type()==QEvent::KeyPress) {
 	QKeyEvent* key_event=(QKeyEvent*)event;
 

--- a/win/tty/getline.c
+++ b/win/tty/getline.c
@@ -185,7 +185,11 @@ register const char *s;	/* chars allowed besides return */
 
     morc = 0;
 
-    while((c = tty_nhgetch()) != '\n') {
+    while(
+#ifdef HANGUPHANDLING
+        !program_state.done_hup &&
+#endif
+	((c = tty_nhgetch()) != '\n')) {
 	if(iflags.cbreak) {
 	    if ((s && index(s,c)) || c == x) {
 		morc = (char) c;

--- a/win/win32/mswproc.c
+++ b/win/win32/mswproc.c
@@ -2346,6 +2346,8 @@ static void mswin_color_from_string(char *colorstring, HBRUSH* brushptr, COLORRE
 int NHMessageBox(HWND hWnd, LPCTSTR text, UINT type)
 {
     TCHAR title[MAX_LOADSTRING];
+    if (program_state.exiting && !strcmp(text, "\n"))
+        text = "Press Enter to exit";
     
     LoadString(GetNHApp()->hApp, IDS_APP_TITLE_SHORT, title, MAX_LOADSTRING);
 


### PR DESCRIPTION
This is an attempt to port both the hangup handling and saferhangup
changes that vanilla has made over the past few versions (3.6-3.7)

This should help deal with issues such as game loss upon disconnecting
at a MORE prompt, and might prevent some of the older hangup cheats

It wasn't a particularly clean process - if something is amiss here it'll
be something rather subtle. Vanilla has changed a lot since the 3.4.3 days
(on which slashem is based)