### PR TITLE
Switch USE_WIN_IOCTL to opt-out

### DIFF
--- a/include/unixconf.h
+++ b/include/unixconf.h
@@ -197,6 +197,8 @@
  */
 /* #define TIMED_DELAY */	/* usleep() */
 
+/* #define AVOID_WIN_IOCTL */ /* ensure USE_WIN_IOCTL remains undefined */
+
 # ifdef TEXTCOLOR
 #  define VIDEOSHADES
 # endif

--- a/sys/share/ioctl.c
+++ b/sys/share/ioctl.c
@@ -63,7 +63,12 @@ struct termio termio;
 #include	<signal.h>
 #endif
 
-#if defined(TIOCGWINSZ) && (defined(BSD) || defined(ULTRIX) || defined(AIX_31) || defined(_BULL_SOURCE) || defined(SVR4))
+/* AVOID_WIN_IOCTL can be uncommented in unixconf.h
+  * to force USE_WIN_IOTCL to remain undefined,
+  * instead of the restricted explicit opt-in
+  * logic that used to be here.
+  */
+#if defined(TIOCGWINSZ) && !defined(AVOID_WIN_IOCTL)
 #define USE_WIN_IOCTL
 #include "tcap.h"	/* for LI and CO */
 #endif


### PR DESCRIPTION
This fixes issues on certain platforms with window resizing or size
detection at game start

Taken from vanilla commit 27a7538e