### PR TITLE
Add the missing tty windowport and signal hangup handling

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2248,6 +2248,7 @@ E int FDECL(flash_hits_mon, (struct monst *,struct obj *));
 /* ### unixmain.c ### */
 
 #ifdef UNIX
+extern void sethanguphandler(void(*)(int));
 # ifdef PORT_HELP
 E void NDECL(port_help);
 # endif

--- a/src/end.c
+++ b/src/end.c
@@ -291,7 +291,7 @@ done_hangup(sig)	/* signal() handler */
 int sig;
 {
 	program_state.done_hup++;
-	(void)signal(SIGHUP, SIG_IGN);
+	sethanguphandler((void (*)(int)) SIG_IGN);
 	done_intr(sig);
 	return;
 }
@@ -883,7 +883,7 @@ die:
 	(void) signal(SIGINT, (SIG_RET_TYPE) done_intr);
 # if defined(UNIX) || defined(VMS) || defined (__EMX__)
 	(void) signal(SIGQUIT, (SIG_RET_TYPE) done_intr);
-	(void) signal(SIGHUP, (SIG_RET_TYPE) done_hangup);
+	sethanguphandler(done_hangup);
 # endif
 #endif /* NO_SIGNAL */
 

--- a/src/files.c
+++ b/src/files.c
@@ -585,9 +585,12 @@ clearlocks()
     if (program_state.preserve_locks)
         return;
 #endif
-# if defined(UNIX) || defined(VMS)
-	(void) signal(SIGHUP, SIG_IGN);
-# endif
+#ifndef NO_SIGNAL
+	(void) signal(SIGINT, SIG_IGN);
+#if defined(UNIX) || defined(VMS)
+	sethanguphandler((void (*)(int)) SIG_IGN);
+#endif
+#endif
 	/* can't access maxledgerno() before dungeons are created -dlc */
 	int x;
 	for (x = (n_dgns ? maxledgerno() : 0); x >= 0; x--)

--- a/src/save.c
+++ b/src/save.c
@@ -145,10 +145,10 @@ dosave0()
 		return 0;
 	fq_save = fqname(SAVEF, SAVEPREFIX, 1);	/* level files take 0 */
 
-#if defined(UNIX) || defined(VMS)
-	(void) signal(SIGHUP, SIG_IGN);
-#endif
 #ifndef NO_SIGNAL
+#if defined(UNIX) || defined(VMS)
+	sethanguphandler((void (*)(int) ) SIG_IGN);
+#endif
 	(void) signal(SIGINT, SIG_IGN);
 #endif
 

--- a/sys/unix/unixmain.c
+++ b/sys/unix/unixmain.c
@@ -150,12 +150,8 @@ char *argv[];
 	u.uhp = 1;	/* prevent RIP on early quits */
 	program_state.preserve_locks = 1;
 
-	(void) signal(SIGHUP, (SIG_RET_TYPE) hangup);
-#ifdef SIGXCPU
-	(void) signal(SIGXCPU, (SIG_RET_TYPE) hangup);
-#endif
-#ifdef SIGPIPE		/* eg., a lost proxy connection */
-	(void) signal(SIGPIPE, (SIG_RET_TYPE) hangup);
+#ifndef NO_SIGNAL
+    sethanguphandler((SIG_RET_TYPE) hangup);
 #endif
 
 	process_options(argc, argv);	/* command line options */
@@ -507,6 +503,36 @@ whoami() {
 	if(!*plname && (s = getlogin()))
 		(void) strncpy(plname, s, sizeof(plname)-1);
 	return TRUE;
+}
+
+void
+sethanguphandler(void (*handler)(int))
+{
+#ifdef SA_RESTART
+    /* don't want reads to restart.  If SA_RESTART is defined, we know
+     * sigaction exists and can be used to ensure reads won't restart.
+     * If it's not defined, assume reads do not restart.  If reads restart
+     * and a signal occurs, the game won't do anything until the read
+     * succeeds (or the stream returns EOF, which might not happen if
+     * reading from, say, a window manager). */
+    struct sigaction sact;
+
+    (void) memset((genericptr_t) &sact, 0, sizeof sact);
+    sact.sa_handler = (SIG_RET_TYPE) handler;
+    (void) sigaction(SIGHUP, &sact, (struct sigaction *) 0);
+#ifdef SIGXCPU
+    (void) sigaction(SIGXCPU, &sact, (struct sigaction *) 0);
+#endif
+#else /* !SA_RESTART */
+    (void) signal(SIGHUP, (SIG_RET_TYPE) handler);
+#ifdef SIGXCPU
+    (void) signal(SIGXCPU, (SIG_RET_TYPE) handler);
+#endif
+    /* not present in vanilla, leaving it here just in case... */
+#ifdef SIGPIPE		/* eg., a lost proxy connection */
+	(void) signal(SIGPIPE, (SIG_RET_TYPE) hangup);
+#endif
+#endif /* ?SA_RESTART */
 }
 
 #ifdef PORT_HELP


### PR DESCRIPTION
When I ported SAFERHANGUP and HANGUPHANDLING I had made a bit of a blunder

Missing was the crucial setup of the signal actions, which meant that the game could hang waiting for input

Additionally the tty windowport specifically wasn't behaving correctly as it had missed several early returns.